### PR TITLE
Use #if defined (KINETISK)

### DIFF
--- a/Adafruit_NeoPixel.cpp
+++ b/Adafruit_NeoPixel.cpp
@@ -722,7 +722,7 @@ void Adafruit_NeoPixel::show(void) {
 
 // ARM MCUs -- Teensy 3.0, 3.1, LC, Arduino Due ---------------------------
 
-#if defined(__MK20DX128__) || defined(__MK20DX256__) // Teensy 3.0 & 3.1
+#if defined(KINETISK) // Teensy 3.0 & 3.1/2 3.4 3.5
 #define CYCLES_800_T0H  (F_CPU / 4000000)
 #define CYCLES_800_T1H  (F_CPU / 1250000)
 #define CYCLES_800      (F_CPU /  800000)


### PR DESCRIPTION
Instead of
if defined(__MK20DX128__) || defined(__MK20DX256__

Now hopefully support the new Teensy 3.4 and 3.5